### PR TITLE
docs: fix README install repository

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -46,7 +46,7 @@ is an one chip/compiler combination upon which the fully-bayesian version code
 encounters some memory problems.  In the meantime, to install the development version
 you can simply do:
 ```r
-remotes::install_github("eriande/rubias")
+remotes::install_github("eriqande/rubias")
 ```
 
 Full pkgdown documentation is now available at [https://eriqande.github.io/rubias/](https://eriqande.github.io/rubias/).

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ fully-bayesian version code encounters some memory problems. In the
 meantime, to install the development version you can simply do:
 
 ``` r
-remotes::install_github("eriande/rubias")
+remotes::install_github("eriqande/rubias")
 ```
 
 Full pkgdown documentation is now available at


### PR DESCRIPTION
## Summary
- correct the development install command from `eriande/rubias` to `eriqande/rubias` in `README.Rmd`
- update the rendered `README.md` copy to match

Fixes #38.

## Validation
- `rg -n 'install_github|eriande|eriqande|URL:|BugReports:' README.Rmd README.md DESCRIPTION -S`\n- `git diff --check`\n- `git ls-remote --heads https://github.com/eriqande/rubias.git master`\n- confirmed `https://github.com/eriande/rubias.git` is not reachable\n\nNo package runtime tests were run because this only corrects the repository slug in README installation documentation.